### PR TITLE
feat(caniuse): add caniuse API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bikeshed-data
+caniuse-data
+caniuse-data-respec
 node_modules
 xref-data.json

--- a/app.js
+++ b/app.js
@@ -15,13 +15,17 @@ app.use(
 // for preflight request
 app.options("/xref", cors({ methods: ["POST"] }));
 app.post("/xref", bodyParser.json(), cors(), require("./routes/xref/").route);
-
 app.post(
   "/xref/update",
-  bodyParser.json({
-    verify: rawBodyParser,
-  }),
+  bodyParser.json({ verify: rawBodyParser }),
   require("./routes/xref/update").route
+);
+
+app.get("/caniuse", require("./routes/caniuse/").route);
+app.post(
+  "/caniuse/update",
+  bodyParser.json({ verify: rawBodyParser }),
+  require("./routes/caniuse/update").route
 );
 
 app.listen(port, () => console.log(`Listening on port ${port}!`));

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "morgan": "^1.9.1",
+    "respec-caniuse-route": "^1.0.2",
     "respec-xref-route": "^2.3.0"
   },
   "scripts": {
     "start": "node app.js",
+    "get-caniuse-data": "fetch-caniuse-data && convert-caniuse-data",
     "get-xref-data": "fetch-bs-data && convert-bs-data"
   }
 }

--- a/routes/caniuse/index.js
+++ b/routes/caniuse/index.js
@@ -1,0 +1,18 @@
+const { createResponseBody } = require("respec-caniuse-route");
+
+module.exports.route = async function route(req, res) {
+  const options = {
+    feature: req.query.feature,
+    browsers: req.query.browsers ? req.query.browsers.split(",") : "default",
+    versions: parseInt(req.query.versions, 10),
+  };
+  if (!options.feature) {
+    res.send(400);
+    return;
+  }
+  if (Number.isNaN(options.versions)) {
+    options.versions = 0;
+  }
+  const body = await createResponseBody(options);
+  res.json(body);
+};

--- a/routes/caniuse/update.js
+++ b/routes/caniuse/update.js
@@ -1,0 +1,49 @@
+const crypto = require("crypto");
+const { exec } = require("child_process");
+const { queue } = require("../../utils/background-task-queue");
+const { cache } = require("respec-caniuse-route");
+
+const caniuseSecret = process.env.CANIUSE_SECRET;
+if (!caniuseSecret) {
+  throw new Error("env variable `CANIUSE_SECRET` is not set.");
+}
+
+module.exports.route = function route(req, res) {
+  if (!isValidGithubSignature(req)) {
+    res.status(401); // Unauthorized
+    return res.send("Failed to authenticate GitHub hook Signature");
+  }
+
+  if (req.body.refs !== "refs/heads/master") {
+    res.status(400); // Bad request
+    return res.send("Payload was not for master, ignored it.");
+  }
+
+  const taskId = `[/caniuse/update]: ${req.get("X-GitHub-Delivery")}`;
+  queue.add(updateData, taskId);
+  res.status(202); // Accepted
+  res.send();
+};
+
+function isValidGithubSignature(req) {
+  // see: https://developer.github.com/webhooks/securing/
+  const hash = crypto
+    .createHmac("sha1", caniuseSecret)
+    .update(req.rawBody)
+    .digest("hex");
+
+  return req.get("X-Hub-Signature") === `sha1=${hash}`;
+}
+
+function updateData() {
+  return new Promise((resolve, reject) => {
+    exec("npm run get-caniuse-data", error => {
+      if (error) {
+        console.error(error);
+        reject(new Error("Error while updating data. See server logs."));
+      }
+      cache.clear();
+      resolve("Succesfully updated.");
+    });
+  });
+}


### PR DESCRIPTION
Mostly copy paste from xref API.
Added github webhook update endpoint also

Also, not that `/caniuse` is a GET endpoint - so we'll be passing query params like:
``` HTTP
GET /caniuse?feature=payment-request&versions=2&browsers=chrome,firefox
```