### PR TITLE
Update respec-caniuse-route dependency and make related changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 .DS_Store
+.vscode
 bikeshed-data
-caniuse-data
-caniuse-data-respec
 node_modules
 xref-data.json
 ecosystem.config.js
 public/
+data

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "express": "^4.16.4",
     "morgan": "^1.9.1",
     "npm-check-updates": "^3.1.2",
-    "respec-caniuse-route": "^1.0.4",
+    "respec-caniuse-route": "^2.0.1",
     "respec-xref-route": "^2.3.0"
   },
   "scripts": {

--- a/routes/caniuse/index.js
+++ b/routes/caniuse/index.js
@@ -14,5 +14,10 @@ module.exports.route = async function route(req, res) {
     options.versions = 0;
   }
   const body = await createResponseBody(options);
+  if (body === null) {
+    res.sendStatus(404);
+    return;
+  }
+
   res.json(body);
 };

--- a/routes/caniuse/index.js
+++ b/routes/caniuse/index.js
@@ -19,5 +19,7 @@ module.exports.route = async function route(req, res) {
     return;
   }
 
+  // cache for 24hours (86400 seconds)
+  res.set('Cache-Control', 'max-age=86400');
   res.json(body);
 };


### PR DESCRIPTION
- Return 404 status if feature file not found, instead of empty object with 200 status
- cache 200 status results for 24h