### PR TITLE
feat(xref/meta): add route to expose metadata

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,8 +13,9 @@ app.use(
 );
 
 // for preflight request
-app.options("/xref", cors({ methods: ["POST"] }));
+app.options("/xref", cors({ methods: ["POST", "GET"] }));
 app.post("/xref", bodyParser.json(), cors(), require("./routes/xref/").route);
+app.get("/xref/meta", cors(), require("./routes/xref/meta").route);
 app.post(
   "/xref/update",
   bodyParser.json({ verify: rawBodyParser }),

--- a/routes/xref/meta.js
+++ b/routes/xref/meta.js
@@ -1,0 +1,32 @@
+const { cache, types } = require("respec-xref-route");
+
+module.exports.route = function route(req, res) {
+  const data = getData();
+  const supportedFields = new Set(Object.keys(data));
+  const fields = (req.query.fields || "")
+    .split(",")
+    .filter(field => supportedFields.has(field));
+
+  if (!fields.length) {
+    res.json(data);
+  } else {
+    const filteredData = pickFields(fields, data);
+    res.json(filteredData);
+  }
+};
+
+// TODO: cache this based on `cache.reset()`
+function getData() {
+  return {
+    types,
+    specs: cache.get("specmap"),
+    terms: Object.keys(cache.get("by_term")),
+  };
+}
+
+function pickFields(fields, data) {
+  return fields.reduce((result, field) => {
+    result[field] = data[field];
+    return result;
+  }, {});
+}


### PR DESCRIPTION
``` http
GET /xref/meta
GET /xref/meta?fields=types,allTypes,specs,terms
```
``` typescript
{
    types: {
        idl: string[],
        concept: string[],
    },
    specs: {
      [spec: string]: {
         url: string, 
         shortname: string,
         title: string,
      }
    },
    terms: string[],
}
```

Depends upon: https://github.com/sidvishnoi/respec-xref-route/pull/34