### PR TITLE
fix(xref/ui): add built-in customElements polyfill

### DIFF
--- a/static/xref/index.html
+++ b/static/xref/index.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Search cross references</title>
     <link rel="stylesheet" href="style.css" />
+    <script>
+      try{customElements.define('built-in',document.createElement('p').constructor,{'extends':'p'})}
+      catch(e){document.write('<script src="//unpkg.com/@ungap/custom-elements-builtin"><\x2fscript>')}
+    </script>
     <script src="script.js" defer></script>
   </head>
   <body>


### PR DESCRIPTION
Closes #35

Concerned about the [Constructor Caveat](https://github.com/ungap/custom-elements-builtin#constructor-caveat). Please test it works in Safari.