### PR TITLE
feat(xref/meta): add cache version

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ app.use(helmet({
 // for preflight request
 app.options("/xref", cors({ methods: ["POST", "GET"] }));
 app.post("/xref", bodyParser.json(), cors(), require("./routes/xref/").route);
-app.get("/xref/meta", cors(), require("./routes/xref/meta").route);
+app.get("/xref/meta/:field?", cors(), require("./routes/xref/meta").route);
 app.post(
   "/xref/update",
   bodyParser.json({ verify: rawBodyParser }),

--- a/routes/xref/meta.js
+++ b/routes/xref/meta.js
@@ -11,6 +11,24 @@ module.exports.route = function route(req, res) {
     data = getData();
   }
 
+  if (req.params.field) {
+    switch (req.params.field) {
+      case "version":
+        res.set("Cache-Control", "no-cache");
+        res.set("Content-Type", "text/plain");
+        res.send(data.version.toString());
+        break;
+      case "types":
+      case "specs":
+      case "terms":
+        res.send(data[req.params.field]);
+        break;
+      default:
+        res.sendStatus(404);
+    }
+    return;
+  }
+
   const fields = (req.query.fields || "")
     .split(",")
     .filter(field => supportedFields.has(field));

--- a/routes/xref/meta.js
+++ b/routes/xref/meta.js
@@ -2,9 +2,15 @@
 const { IDL_TYPES, CONCEPT_TYPES } = require("respec-xref-route/constants");
 const { cache } = require("respec-xref-route/cache");
 
+let data = getData();
+
+const supportedFields = new Set(Object.keys(data));
+
 module.exports.route = function route(req, res) {
-  const data = getData();
-  const supportedFields = new Set(Object.keys(data));
+  if (data.version < cache.version) {
+    data = getData();
+  }
+
   const fields = (req.query.fields || "")
     .split(",")
     .filter(field => supportedFields.has(field));
@@ -17,7 +23,6 @@ module.exports.route = function route(req, res) {
   }
 };
 
-// TODO: cache this based on `cache.reset()`
 function getData() {
   const terms = Object.keys(cache.get("by_term"));
   terms.splice(terms.indexOf(""), 1, '""');
@@ -29,6 +34,7 @@ function getData() {
     },
     specs: cache.get("specmap"),
     terms,
+    version: cache.version,
   };
 }
 


### PR DESCRIPTION
Also added parameterized routes (`/xref/meta/version`, `/xref/meta/types` etc.) for fine-tuned response (can fine-tune cache-control on `/xref/meta/version` without affecting others, while keeping it in same "parent route")... and also as they're easier to write.

https://github.com/w3c/respec/pull/2473 depends on this.