### PR TITLE
 feat(xref): log error counts

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,12 +9,16 @@ const app = express();
 const helmet = require("helmet");
 app.use(compression());
 
-
-// loggin
+// logging
+morgan.token("locals", (req, res) => {
+  if (Object.keys(res.locals).length) {
+    return JSON.stringify(res.locals);
+  }
+});
 app.enable("trust proxy"); // for :remote-addr
 app.use(
   morgan(
-    ":date[iso] | :remote-addr | :method :status :url | :referrer | :res[content-length] | :response-time ms"
+    ":date[iso] | :remote-addr | :method :status :url | :referrer | :res[content-length] | :response-time ms | :locals",
   )
 );
 

--- a/routes/xref/index.js
+++ b/routes/xref/index.js
@@ -2,7 +2,24 @@
 const { search } = require("respec-xref-route/search");
 
 module.exports.route = function route(req, res) {
-  const { keys, options } = req.body;
+  const { keys = [], options } = req.body;
   const body = search(keys, options);
+
+  const errors = getErrorCount(body.result);
+  if (errors / keys.length > 0.05) {
+    // add to logs if error rate is more than 5%
+    Object.assign(res.locals, { errors, queries: keys.length });
+  }
+
   res.json(body);
 };
+
+function getErrorCount(results) {
+  let errorCount = 0;
+  for (const [, entries] of results) {
+    if (entries.length !== 1) {
+      errorCount++;
+    }
+  }
+  return errorCount;
+}

--- a/routes/xref/index.js
+++ b/routes/xref/index.js
@@ -6,10 +6,8 @@ module.exports.route = function route(req, res) {
   const body = search(keys, options);
 
   const errors = getErrorCount(body.result);
-  if (errors / keys.length > 0.05) {
-    // add to logs if error rate is more than 5%
-    Object.assign(res.locals, { errors, queries: keys.length });
-  }
+  // add error stats to logs
+  Object.assign(res.locals, { errors, queries: keys.length });
 
   res.json(body);
 };


### PR DESCRIPTION
It looks like this:
```
Listening on port 8000!
2019-08-19T09:55:15.809Z | ::1 | POST 200 /xref/ | - | 155 | 20.678 ms | -
2019-08-19T09:55:19.248Z | ::1 | POST 200 /xref/ | - | 251 | 1.585 ms | {"errors":2,"queries":3}
```