### PR TITLE
 feat(logging): reduce noise in logs

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,24 +3,16 @@ const express = require("express");
 const bodyParser = require("body-parser");
 const cors = require("cors");
 const compression = require("compression");
-const rawBodyParser = require("./utils/raw-body-parser");
-const morgan = require("morgan");
-const app = express();
 const helmet = require("helmet");
+const rawBodyParser = require("./utils/raw-body-parser");
+const logging = require("./utils/logging");
+
+const app = express();
 app.use(compression());
 
 // logging
-morgan.token("locals", (req, res) => {
-  if (Object.keys(res.locals).length) {
-    return JSON.stringify(res.locals);
-  }
-});
 app.enable("trust proxy"); // for :remote-addr
-app.use(
-  morgan(
-    ":date[iso] | :remote-addr | :method :status :url | :referrer | :res[content-length] | :response-time ms | :locals",
-  )
-);
+app.use(logging());
 
 app.use(express.static("static"));
 // Security

--- a/utils/logging.js
+++ b/utils/logging.js
@@ -1,0 +1,13 @@
+// @ts-check
+const morgan = require("morgan");
+
+morgan.token("locals", (req, res) => {
+  if (Object.keys(res.locals).length) {
+    return JSON.stringify(res.locals);
+  }
+});
+
+const format =
+  ":date[iso] | :remote-addr | :method :status :url | :referrer | :res[content-length] | :response-time ms | :locals";
+
+module.exports = () => morgan(format);

--- a/utils/logging.js
+++ b/utils/logging.js
@@ -10,4 +10,21 @@ morgan.token("locals", (req, res) => {
 const format =
   ":date[iso] | :remote-addr | :method :status :url | :referrer | :res[content-length] | :response-time ms | :locals";
 
-module.exports = () => morgan(format);
+/** @type {import('morgan').Options} */
+const options = {
+  skip(req, res) {
+    const { method, path, hostname } = req;
+    const { statusCode } = res;
+    switch (true) {
+      // /xref pre-flight request
+      case method === "OPTIONS" && path === "/xref" && statusCode === 204:
+      // automated tests
+      case hostname === "localhost:9876":
+        return true;
+      default:
+        return false;
+    }
+  },
+};
+
+module.exports = () => morgan(format, options);

--- a/utils/logging.js
+++ b/utils/logging.js
@@ -15,15 +15,12 @@ const options = {
   skip(req, res) {
     const { method, path, hostname } = req;
     const { statusCode } = res;
-    switch (true) {
+    return (
       // /xref pre-flight request
-      case method === "OPTIONS" && path === "/xref" && statusCode === 204:
+      (method === "OPTIONS" && path === "/xref" && statusCode === 204) ||
       // automated tests
-      case hostname === "localhost:9876":
-        return true;
-      default:
-        return false;
-    }
+      hostname === "localhost:9876"
+    );
   },
 };
 


### PR DESCRIPTION
removes  following patterns from logs:
- automated tests: `localhost:9876/*`
- pre-flight requests to xref search: `OPTIONS 204 /xref` 