### PR TITLE
enhancement(github/commits): get commits in range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -538,9 +538,9 @@
       "integrity": "sha512-MZsY07i0BxIUu8QWlNHCMbbm5A3VwwlTxk5bWPq/OhBSxgyEbjDWUgv1NKMHUaPa67fK53oSRXP6UxCRA0Vuig=="
     },
     "respec-github-apis": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/respec-github-apis/-/respec-github-apis-1.0.0.tgz",
-      "integrity": "sha512-kXJZh5gLq7i9z7my3GW9qhDm0vaSKLvbxMDA1IprhGu+6bqp7qhlHXXHClfPh4DpnmiTylCaN6PDhclcAPJh9w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/respec-github-apis/-/respec-github-apis-1.3.0.tgz",
+      "integrity": "sha512-lrfhZHGHGwfp4z+9ZPmZbl5CVj4hKEkJKK0uKDrcdTT4H+Ko72a+DOchwNB2iN5cNUUMMU48K89VTK1qNyh90g==",
       "requires": {
         "node-fetch": "^2.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "helmet": "^3.21.1",
     "morgan": "^1.9.1",
     "respec-caniuse-route": "^3.0.2",
-    "respec-github-apis": "^1.2.0",
+    "respec-github-apis": "^1.3.0",
     "respec-xref-route": "^6.1.0"
   },
   "scripts": {

--- a/routes/github/commits.js
+++ b/routes/github/commits.js
@@ -7,10 +7,10 @@ const { getCommits } = require("respec-github-apis/commits");
  */
 module.exports.route = async function route(req, res) {
   const { org, repo } = req.params;
-  const { since } = req.query;
-  if (!since || typeof since !== "string") {
+  const { from, to } = req.query;
+  if (!from || typeof from !== "string") {
     res.set("Content-Type", "text/plain");
-    return res.status(400).send("query parameter 'since' is required");
+    return res.status(400).send("query parameter 'from' is required");
   }
 
   // cache all results for 30 min (1800 seconds)
@@ -18,7 +18,7 @@ module.exports.route = async function route(req, res) {
 
   try {
     const commits = [];
-    for await (const commit of getCommits(org, repo, since)) {
+    for await (const commit of getCommits(org, repo, from, to)) {
       commits.push({
         hash: commit.abbreviatedOid,
         message: commit.messageHeadline,


### PR DESCRIPTION
* rename required query param "since" to "from"
* add new query param "to"
* update respec-github-api to 1.3.0 (Changelog [v1.2.0...v1.3.0](https://github.com/sidvishnoi/respec-github-apis/compare/v1.2.0...v1.3.0))