### PR TITLE
chore: use dotenv package to read env vars

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,16 @@
+# Copy this file as `.env` in project's root directory and change the values.
+
+# GitHub API Personal Token
+GH_TOKEN=xxxxxxxxxxxxxxxxxxxxxx
+
+# Full path to data directory
+DATA_DIR=/home/respec.org/data
+
+# GitHub webhook secrets
+BIKESHED_SECRET=xxxxxxxxxxxxxxxxxxxxxx
+CANIUSE_SECRET=xxxxxxxxxxxxxxxxxxxxxx
+
+# GitHub Action secret on w3c/respec
+RESPEC_SECRET=xxxxxxxxxxxxxxxxxxxxxx
+
+W3C_API_KEY=xxxxxxxxxxxxxxxxxxxxxx

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 ecosystem.config.js
 public/
 data
+.env

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-const port = parseInt(process.env.PORT, 10) || 8000;
+require("dotenv").config();
 const express = require("express");
 const compression = require("compression");
 const helmet = require("helmet");
@@ -24,4 +24,5 @@ app.use("/xref", require("./routes/xref/").routes);
 app.use("/caniuse", require("./routes/caniuse/").routes);
 app.use("/github/:org/:repo", require("./routes/github/").routes);
 
+const port = parseInt(process.env.PORT, 10) || 8000;
 app.listen(port, () => console.log(`Listening on port ${port}!`));

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,6 +198,11 @@
       "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz",
       "integrity": "sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug=="
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "chalk": "^4.0.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "helmet": "^3.22.0",
     "morgan": "^1.10.0",


### PR DESCRIPTION
Better than fiddling with env variables in pm2 config file and bashrc