### PR TITLE
fix(respec/size): add new line while appending entry

### DIFF
--- a/routes/respec/size.js
+++ b/routes/respec/size.js
@@ -75,7 +75,7 @@ async function putHandler(req, res) {
     return res.sendStatus(412);
   }
 
-  await fs.appendFile(FILE_PATH, JSON.stringify(entry));
+  await fs.appendFile(FILE_PATH, `${JSON.stringify(entry)}\n`);
   res.sendStatus(201);
 }
 


### PR DESCRIPTION
Dashboard borked as we got entries like this while parsing newline delimited JSON:
```
{"sha": "49759ff", "time": 1590125810, "size": 295042, "gzipSize": 93329 }
{"sha": "a84344f", "time": 1590141883, "size": 295042, "gzipSize": 93329 }
{"sha":"a48a66dfb5","time":1590496824,"size":294849,"gzipSize":93369}{"sha":"9c43e5d9c5","time":1590506844,"size":294847,"gzipSize":93366}{"sha":"31b41406eb","time":1590606816,"size":294847,"gzipSize":93366}
```