### PR TITLE
fix(xref-ui): how-to-cite element-attr without forContext

### DIFF
--- a/static/xref/.prettierrc
+++ b/static/xref/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
+  "arrowParens": "avoid",
   "trailingComma": "all"
 }

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -175,6 +175,9 @@ function howToCiteMarkup(term, entry) {
   if (forList) {
     return forList.map(f => `[^${f}/${term}^]`).join('<br>');
   }
+  if (type === 'element-attr') {
+    return `[^/${term}^]`;
+  }
   return `[^${term}^]`;
 }
 


### PR DESCRIPTION
Closes https://github.com/sidvishnoi/respec-xref-route/issues/63
Already supported in w3c/respec and sidvishnoi/respec-xref-route