### PR TITLE
feat(w3c/groups): get detailed information on group list

### DIFF
--- a/routes/w3c/group.js
+++ b/routes/w3c/group.js
@@ -5,6 +5,10 @@ const { env, ms, seconds } = require("../../utils/misc.js");
 const groups = require("./groups.json");
 
 const API_KEY = env("W3C_API_KEY");
+/**
+ * @typedef {{ id: number, group: string, name: string, URI: string, patentURI: string }} Group
+ * @type {MemCache<Group>}
+ */
 const cache = new MemCache(ms("2 weeks"));
 
 /**
@@ -14,7 +18,8 @@ const cache = new MemCache(ms("2 weeks"));
 module.exports.route = async function route(req, res) {
   const { groupName } = req.params;
   if (!groupName) {
-    return res.json(groups);
+    const data = await getAllGroupInfo();
+    return res.json(data);
   }
 
   try {
@@ -51,15 +56,27 @@ async function getGroupInfo(groupName) {
   }
   const json = await res.json();
 
-  const { id, name, description, _links: links } = json;
+  const { id, name, _links: links } = json;
+  /** @type {Group} */
   const result = {
+    group: groupName,
     id,
     name,
-    description,
     URI: links.homepage.href,
     patentURI: links["pp-status"].href,
   };
 
   cache.set(groupName, result);
   return result;
+}
+
+async function getAllGroupInfo() {
+  const groupNames = Object.keys(groups);
+
+  // Fill the cache with the groups not fetched recently.
+  await Promise.allSettled(groupNames.map(getGroupInfo));
+
+  return groupNames.map(
+    group => cache.get(group) || { group, id: groups[group] },
+  );
 }

--- a/routes/w3c/group.js
+++ b/routes/w3c/group.js
@@ -59,7 +59,7 @@ async function getGroupInfo(groupName) {
   const { id, name, _links: links } = json;
   /** @type {Group} */
   const result = {
-    group: groupName,
+    shortname: groupName,
     id,
     name,
     URI: links.homepage.href,


### PR DESCRIPTION
- `GET /w3c/groups` returns more information (instead of just group -> id)
  - Note that first request to this URL will be slow, unless different group results are already cached.
- The return type is now an array instead of an object all groups
- Removed `description` field, as it was unused
- Improved type definitions

![image](https://user-images.githubusercontent.com/8426945/85867755-f476aa00-b7e6-11ea-9838-2de8ceb156d6.png)
