### PR TITLE
fix(respec/size): use xferSize instead of gzipSize

### DIFF
--- a/routes/respec/size.js
+++ b/routes/respec/size.js
@@ -48,7 +48,7 @@ const lastFewEntries = [];
  * @param {import('express').Request} req
  * @param {import('express').Response} res
  *
- * @typedef {{ sha: string, time: number, size: number, gzipSize: number }} Entry
+ * @typedef {{ sha: string, time: number, size: number, xferSize: number }} Entry
  * @typedef {{ commits: Entry[] }} Data
  */
 async function putHandler(req, res) {
@@ -59,12 +59,12 @@ async function putHandler(req, res) {
   /** @type {string} */
   const sha = req.body.sha;
   const size = parseInt(req.body.size, 10);
-  const gzipSize = parseInt(req.body.gzipSize, 10);
+  const xferSize = parseInt(req.body.xferSize, 10);
   const time = parseInt(req.body.timestamp, 10);
-  if (!size || !gzipSize || !time || !/^([a-f0-9]{40})$/.test(sha)) {
+  if (!size || !xferSize || !time || !/^([a-f0-9]{40})$/.test(sha)) {
     return res.sendStatus(400);
   }
-  const entry = { sha: sha.slice(0, 10), time, size, gzipSize };
+  const entry = { sha: sha.slice(0, 10), time, size, xferSize };
 
   if (!ensureUnique(entry)) {
     return res.sendStatus(412);

--- a/static/dashboard/index.html
+++ b/static/dashboard/index.html
@@ -14,7 +14,7 @@
     <header>
       <h2>Size of respec-w3c profile over time</h2>
       <form id="size-form">
-        <label><input type="checkbox" name="gzipSize" checked> <span>Show gzip size</span></label>
+        <label><input type="checkbox" name="xferSize" checked> <span>Show transferred size</span></label>
         <select name="duration">
           <option value="0">All time</option>
           <option value="12">Last year</option>

--- a/static/dashboard/size-chart.js
+++ b/static/dashboard/size-chart.js
@@ -2,7 +2,7 @@ google.charts.load("current", { packages: ["line", "corechart"] });
 google.charts.setOnLoadCallback(main);
 
 const form = document.getElementById("size-form");
-const columnMap = { time: 0, sha: 1, size: 2, gzipSize: 3 };
+const columnMap = { time: 0, sha: 1, size: 2, xferSize: 3 };
 
 async function main() {
   const entries = await fetchData();
@@ -36,7 +36,7 @@ function getDataTable(entries) {
 
 /** @param {google.visualization.DataTable} data */
 function drawChart(data) {
-  const { checked: showGzipSize } = form.gzipSize;
+  const { checked: showTransferredSize } = form.xferSize;
   const months = parseInt(form.duration.value, 10);
 
   let viewWindow;
@@ -46,7 +46,7 @@ function drawChart(data) {
     viewWindow = { min: date };
   }
 
-  const title = showGzipSize ? "Size (gzip, bytes)" : "Size (bytes)";
+  const title = showTransferredSize ? "Size (br/gzip, bytes)" : "Size (bytes)";
   /** @type {google.visualization.LineChartOptions} */
   const drawOptions = {
     theme: "maximized",
@@ -75,7 +75,7 @@ function drawChart(data) {
   });
 
   const view = new google.visualization.DataView(data);
-  const key = showGzipSize ? "gzipSize" : "size";
+  const key = showTransferredSize ? "xferSize" : "size";
   view.setColumns([columnMap.time, columnMap[key]]);
   chart.draw(view, drawOptions);
 }


### PR DESCRIPTION
as we now use brotli instead of gzip only and "transfer" is more generic than "gzip" or "brotli"

Also see: https://github.com/w3c/respec/pull/3008
I'll update past data on server manually.