### PR TITLE
Rename Second Screen WG

### DIFF
--- a/routes/w3c/groups.json
+++ b/routes/w3c/groups.json
@@ -15,7 +15,7 @@
     "payments": 83744,
     "pointer-events": 59096,
     "publishing": 100074,
-    "second-screen": 74168,
+    "secondscreen": 74168,
     "service-workers": 101220,
     "svg": 19480,
     "testing": 49799,


### PR DESCRIPTION
Shortname is `secondscreen` in W3C, e.g. https://www.w3.org/groups/wg/secondscreen
(Second Screen WG specs do not yet use this label, so change shouldn't break anything)