### PR TITLE
perf(w3c/groups): use preloaded basic details

### DIFF
--- a/routes/w3c/group.js
+++ b/routes/w3c/group.js
@@ -38,11 +38,10 @@ const LEGACY_SHORTNAMES = new Map([
 module.exports.route = async function route(req, res) {
   const { shortname, type } = req.params;
   if (!shortname) {
-    const data = await getAllGroupInfo();
     if (req.headers.accept.includes("text/html")) {
-      return res.render("w3c/groups.js", { groups: data });
+      return res.render("w3c/groups.js", { groups });
     }
-    return res.json(data);
+    return res.json(groups);
   }
 
   if (LEGACY_SHORTNAMES.has(shortname)) {
@@ -83,22 +82,6 @@ async function getGroupInfo(shortname, requestedType) {
     cache.set(`${shortname}/${type}`, groupInfo);
   }
   return groupInfo;
-}
-
-async function getAllGroupInfo() {
-  /** @type {[string, Group["type"]][]} */
-  const allGroups = Object.keys(groups).flatMap(type =>
-    Object.keys(groups[type]).map(name => [name, type]),
-  );
-
-  // fill cache
-  await Promise.allSettled(
-    allGroups.map(([name, type]) => getGroupInfo(name, type)),
-  );
-
-  return allGroups.map(
-    ([name, type]) => cache.get(`${name}/${type}`) || getGroupMeta(name, type),
-  );
 }
 
 /**
@@ -162,7 +145,7 @@ function getGroupMeta(shortname, requestedType) {
     .map(type => {
       if (groups[type].hasOwnProperty(shortname)) {
         /** @type {number} */
-        const id = groups[type][shortname];
+        const id = groups[type][shortname].id;
         return { shortname, type, id };
       }
     })

--- a/scripts/update-w3c-groups-list.js
+++ b/scripts/update-w3c-groups-list.js
@@ -29,13 +29,14 @@ async function update() {
     if (!type) continue;
 
     const { shortname, id, name } = group;
+    const url = group._links.homepage?.href;
 
     if (!shortname) {
       console.error(`No shortname for ${name} (${id}).`);
       continue;
     }
 
-    data[type][shortname] = id;
+    data[type][shortname] = { id, name, URI: url };
   }
 
   // Sort results for presentation.

--- a/views/w3c/groups.js
+++ b/views/w3c/groups.js
@@ -64,7 +64,7 @@ module.exports = ({ groups }) => html`
       <h1>W3C Working Groups and Community Groups supported by ReSpec</h1>
       <p>
         List of possible values for
-        <a href="/docs/#group"><code>respecConfig.group</code></a>
+        <a href="/docs/#group"><code>respecConfig.group</code></a>.
       </p>
       <div class="tables">
         ${renderTable(groups.wg, "Working Groups")}

--- a/views/w3c/groups.js
+++ b/views/w3c/groups.js
@@ -64,18 +64,11 @@ module.exports = ({ groups }) => html`
       <h1>W3C Working Groups and Community Groups supported by ReSpec</h1>
       <p>
         List of possible values for
-        <a href="/docs/#group"><code>respecConfig.group</code></a>.
-        Send a Pull Request to <a href=${PR_URL}>add missing groups.</a>
+        <a href="/docs/#group"><code>respecConfig.group</code></a>
       </p>
       <div class="tables">
-        ${renderTable(
-          groups.filter(({ type }) => type === "wg"),
-          "Working Groups",
-        )}
-        ${renderTable(
-          groups.filter(({ type }) => type === "cg"),
-          "Community Groups",
-        )}
+        ${renderTable(groups.wg, "Working Groups")}
+        ${renderTable(groups.cg, "Community Groups")}
       </div>
     </body>
   </html>
@@ -95,13 +88,13 @@ function renderTable(groups, caption) {
         </tr>
       </thead>
       <tbody>
-        ${groups.map(renderGroup)}
+        ${Object.entries(groups).map(renderGroup)}
       </tbody>
     </table>
   `;
 }
 
-function renderGroup({ shortname, id, URI, name }) {
+function renderGroup([shortname, { id, URI, name }]) {
   return html`
     <tr>
       <td><code>${shortname}</code></td>


### PR DESCRIPTION
#116 added support for lots of groups, so fetching all details on `GET /w3c/groups` will be slow as :turtle:.
As we're already collecting shortnames from W3C API, we can save some more details and show them on `/groups/`. 

TODO (followup): Show group-type-qualified name in UI (show `wot/wg` in shortname instead of `wot`).