### PR TITLE
fix(docs): fix duplicate id

### DIFF
--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -312,7 +312,7 @@
       <section data-include="h1-element"></section>
       <section data-include="pre-and-code-elements"></section>
       <section data-include="section"></section>
-      <section data-include="title"></section>
+      <section data-include="title-element"></section>
     </section>
     <section>
       <h2>CSS classes</h2>


### PR DESCRIPTION
https://github.com/w3c/respec/issues/3178 says:
> Duplicate ID title. There are 2 instances of id="title" on same page. One for h1 id="title" class="title" and another one for section id="title"

I'll edit wiki (page title and its references) right before uploading this on server.
