### PR TITLE
fix(docs): don't use obsolete align attribute in tables

### DIFF
--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -31,6 +31,7 @@
           fixLinks,
           addWikiLinks,
           fixMarkupPostprocess,
+          fixTableAlign,
           postProcessEnhance,
           cleanup,
         ],
@@ -136,6 +137,14 @@
           if (elem.innerHTML.includes("\\|")) {
             elem.innerHTML = elem.innerHTML.replace(/\\\|/g, "|");
           }
+        }
+      }
+
+      function fixTableAlign() {
+        for(const elem of document.querySelectorAll("[align]")) {
+          const className = `align-${elem.getAttribute("align")}`;
+          elem.classList.add(className);
+          elem.removeAttribute("align");
         }
       }
 

--- a/static/docs/style.css
+++ b/static/docs/style.css
@@ -17,6 +17,18 @@ table.def th {
   width: auto !important;
 }
 
+.align-left {
+    text-align: left;
+}
+
+.align-right {
+    text-align: right;
+}
+
+.align-center {
+    text-align: center;
+}
+
 h2 code,
 h3 code,
 h4 code {


### PR DESCRIPTION
# Initial Error
The align attribute on the th element is obsolete. Use CSS instead. 
The issue was discussed in w3c/respec#3178

# Files Changed
- static/docs/src.html
- styles.css

# About the pull request
As discussed added a postProcess which resolves the issue.

@sidvishnoi Kindly review this and do let me know if any changes are required in this
