### PR TITLE
fix(docs): processing error due to markdown config

### DIFF
--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -45,7 +45,6 @@
         ],
         canonicalURI: "https://respec.org/docs/",
         github: "w3c/respec",
-        format: "markdown",
         otherLinks: [
           {
             key: "Edit this documentation",


### PR DESCRIPTION
`format: "markdown"` interfered with `data-include-format="markdown"`, causing an error in console during infoString parsing. This combined with https://github.com/marcoscaceres/respec.org/pull/127 prevent docs from updating..