### PR TITLE
fix(w3c/groups): don't use deprecated res.redirect signature

### DIFF
--- a/routes/w3c/group.js
+++ b/routes/w3c/group.js
@@ -49,7 +49,7 @@ export default async function route(req, res) {
   }
 
   if (LEGACY_SHORTNAMES.has(shortname)) {
-    return res.redirect(`/w3c/groups/${LEGACY_SHORTNAMES.get(shortname)}`, 301);
+    return res.redirect(301, `/w3c/groups/${LEGACY_SHORTNAMES.get(shortname)}`);
   }
 
   if (type && !groups.hasOwnProperty(type)) {


### PR DESCRIPTION
Closes https://github.com/marcoscaceres/respec.org/issues/135