### PR TITLE
feat(utils/logging): make URL params cleaner

### DIFF
--- a/utils/logging.js
+++ b/utils/logging.js
@@ -57,10 +57,14 @@ const formatter = (tokens, req, res) => {
   const responseTime = tokens["response-time"](req, res);
   const locals = Object.keys(res.locals).length ? { ...res.locals } : null;
 
+  // Cleaner searchParams, while making sure they stay in single line.
+  const searchParams = url.search
+    ? decodeURIComponent(url.search).replace(/(\s+)/g, encodeURIComponent)
+    : "";
   const color = status < 300 ? "green" : status >= 400 ? "red" : "yellow";
   const request =
     chalk[color](`${method.padEnd(4)} ${status}`) +
-    ` ${chalk.blueBright(url.pathname)}${chalk.italic.gray(url.search)}`;
+    ` ${chalk.blueBright(url.pathname)}${chalk.italic.gray(searchParams)}`;
 
   let formattedReferrer;
   if (referrer) {


### PR DESCRIPTION
**Before:** `GET 200 /github/w3c/repo/issues?issues=1%2C2%2C3%2C4%2C5%2C6%2C10%2C1220&path=%0Ahello%0Aworld`
**After :** `GET 200 /github/w3c/repo/issues?issues=1,2,3,4,5,6,10,1220&path=%0Ahello%0Aworld`

Such URLs can be created in ReSpec as:
```js
const url = new URL("/github/w3c/repo/issues", "http://localhost:8000/");
// real case
url.searchParams.set("issues", [1,2,3,4,5,6,10,1220].join(","));
// edge case or bad actor trying to ruin pretty our logs
url.searchParams.set("path", `
hello
world`);
```