### PR TITLE
refactor(route/caniuse): merge respec-caniuse-route to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,15 @@
         "@types/node": "*"
       }
     },
+    "@types/split2": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@types/split2/-/split2-2.1.6.tgz",
+      "integrity": "sha512-ddaFSOMuy2Rp97l6q/LEteQygvTQJuEZ+SRhxFKR0uXGsdbFDqX/QF2xoGcOqLQ8XV91v01SnAv2vpgihNgW/Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -628,6 +637,16 @@
         "unpipe": "1.0.0"
       }
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -718,10 +737,33 @@
         "source-map": "^0.6.0"
       }
     },
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "requires": {
+        "readable-stream": "^3.0.0"
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
     },
     "supports-color": {
       "version": "7.2.0",
@@ -811,6 +853,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -652,11 +652,6 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
-    "respec-caniuse-route": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/respec-caniuse-route/-/respec-caniuse-route-3.1.1.tgz",
-      "integrity": "sha512-Bkkh/v9uU3UOzS9ZnCM8Q2qRFhMNPysWI5FzK0/bF5t859SCxrGtatNGe4Ok6g0qWsS98KVyIbVKBH314Nvz2g=="
-    },
     "respec-github-apis": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/respec-github-apis/-/respec-github-apis-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "respec-caniuse-route": "^3.1.1",
     "respec-github-apis": "^2.0.0",
     "respec-xref-route": "^9.0.4",
+    "split2": "^3.2.2",
     "ucontent": "^2.0.0"
   },
   "scripts": {
@@ -39,6 +40,7 @@
     "@types/express": "^4.17.11",
     "@types/node": "^14.14.25",
     "@types/node-fetch": "^2.5.8",
+    "@types/split2": "^2.1.6",
     "typescript": "^4.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "helmet": "^4.1.0",
     "morgan": "^1.10.0",
     "node-fetch": "^2.6.1",
-    "respec-caniuse-route": "^3.1.1",
     "respec-github-apis": "^2.0.0",
     "respec-xref-route": "^9.0.4",
     "split2": "^3.2.2",

--- a/routes/caniuse/index.js
+++ b/routes/caniuse/index.js
@@ -5,7 +5,7 @@ import cors from "cors";
 import authGithubWebhook from "../../utils/auth-github-webhook.js";
 import { env, seconds } from "../../utils/misc.js";
 
-import { createResponseBody } from "respec-caniuse-route";
+import { createResponseBody } from "./lib/index.js";
 import updateRoute from "./update.js";
 
 const caniuse = Router({ mergeParams: true });

--- a/routes/caniuse/lib/README.md
+++ b/routes/caniuse/lib/README.md
@@ -1,0 +1,1 @@
+This directory was originally maintained in a separate repository at https://github.com/sidvishnoi/respec-caniuse-route.

--- a/routes/caniuse/lib/constants.ts
+++ b/routes/caniuse/lib/constants.ts
@@ -1,0 +1,28 @@
+export const BROWSERS = new Map([
+  ['and_chr', 'Chrome (Android)'],
+  ['and_ff', 'Firefox (Android)'],
+  ['and_uc', 'UC Browser (Android)'],
+  ['android', 'Android'],
+  ['bb', 'Blackberry'],
+  ['chrome', 'Chrome'],
+  ['edge', 'Edge'],
+  ['firefox', 'Firefox'],
+  ['ie', 'IE'],
+  ['ios_saf', 'Safari (iOS)'],
+  ['op_mini', 'Opera Mini'],
+  ['op_mob', 'Opera Mobile'],
+  ['opera', 'Opera'],
+  ['safari', 'Safari'],
+  ['samsung', 'Samsung Internet'],
+]);
+
+// Keys from https://github.com/Fyrd/caniuse/blob/master/CONTRIBUTING.md
+export const SUPPORT_TITLES = new Map([
+  ['y', 'Supported.'],
+  ['a', 'Almost supported (aka Partial support).'],
+  ['n', 'No support, or disabled by default.'],
+  ['p', 'No support, but has Polyfill.'],
+  ['u', 'Support unknown.'],
+  ['x', 'Requires prefix to work.'],
+  ['d', 'Disabled by default (needs to enabled).'],
+]);

--- a/routes/caniuse/lib/index.ts
+++ b/routes/caniuse/lib/index.ts
@@ -1,0 +1,159 @@
+import * as path from "path";
+import { promises as fs } from "fs";
+
+import { html } from "ucontent";
+
+import { BROWSERS, SUPPORT_TITLES } from "./constants.js";
+import { env } from "../../../utils/misc.js";
+import { MemCache } from "../../../utils/mem-cache.js";
+
+const DATA_DIR = env("DATA_DIR");
+
+interface Options {
+  feature: string;
+  browsers?: string[];
+  versions?: number;
+  format?: "html" | "json";
+}
+type NormalizedOptions = Required<Options>;
+
+type SupportKeys = ("y" | "n" | "a" | string)[];
+// [ version, ['y', 'n'] ]
+type BrowserVersionData = [string, SupportKeys];
+
+interface Data {
+  [browserName: string]: BrowserVersionData[];
+}
+
+const defaultOptions = {
+  browsers: ["chrome", "firefox", "safari", "edge"],
+  versions: 4,
+};
+
+// Content in this cache is invalidated through `POST /caniuse/update`.
+export const cache = new MemCache<Data>(Infinity);
+
+export async function createResponseBody(options: Options) {
+  const opts = normalizeOptions(options);
+
+  switch (opts.format) {
+    case "json":
+      return await createResponseBodyJSON(opts);
+    case "html":
+    default:
+      return await createResponseBodyHTML(opts);
+  }
+}
+
+export async function createResponseBodyJSON(options: NormalizedOptions) {
+  const { feature, browsers, versions } = options;
+  const data = await getData(feature);
+  if (!data) {
+    return null;
+  }
+
+  if (!browsers.length) {
+    browsers.push(...Object.keys(data));
+  }
+
+  const response: Data = Object.create(null);
+  for (const browser of browsers) {
+    const browserData = data[browser] || [];
+    response[browser] = browserData.slice(0, versions);
+  }
+  return response;
+}
+
+export async function createResponseBodyHTML(options: NormalizedOptions) {
+  const data = await createResponseBodyJSON(options);
+  return data === null ? null : formatAsHTML(options, data);
+}
+
+function normalizeOptions(options: Options): NormalizedOptions {
+  const feature = options.feature;
+  const versions = options.versions || defaultOptions.versions;
+  const browsers = sanitizeBrowsersList(options.browsers);
+  const format = options.format === "html" ? "html" : "json";
+  return { feature, versions, browsers, format };
+}
+
+function sanitizeBrowsersList(browsers?: string | string[]) {
+  if (!Array.isArray(browsers)) {
+    if (browsers === "all") return [];
+    return defaultOptions.browsers;
+  }
+  const filtered = browsers.filter(browser => BROWSERS.has(browser));
+  return filtered.length ? filtered : defaultOptions.browsers;
+}
+
+async function getData(feature: string) {
+  if (cache.has(feature)) {
+    return cache.get(feature) as Data;
+  }
+  const file = path.format({
+    dir: path.join(DATA_DIR, "caniuse"),
+    name: `${feature}.json`,
+  });
+
+  try {
+    const str = await fs.readFile(file, "utf8");
+    const data: Data = JSON.parse(str);
+    cache.set(feature, data);
+    return data;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}
+
+function formatAsHTML(options: NormalizedOptions, data: Data) {
+  const getSupportTitle = (keys: SupportKeys) => {
+    return keys
+      .filter(key => SUPPORT_TITLES.has(key))
+      .map(key => SUPPORT_TITLES.get(key)!)
+      .join(" ");
+  };
+
+  const getClassName = (keys: SupportKeys) => `caniuse-cell ${keys.join(" ")}`;
+
+  const renderLatestVersion = (
+    browserName: string,
+    [version, supportKeys]: BrowserVersionData,
+  ) => {
+    const text = `${BROWSERS.get(browserName) || browserName} ${version}`;
+    const className = getClassName(supportKeys);
+    const title = getSupportTitle(supportKeys);
+    return html`<button class="${className}" title="${title}">${text}</button>`;
+  };
+
+  const renderOlderVersion = ([version, supportKeys]: BrowserVersionData) => {
+    const text = version;
+    const className = getClassName(supportKeys);
+    const title = getSupportTitle(supportKeys);
+    return html`<li class="${className}" title="${title}">${text}</li>`;
+  };
+
+  const renderBrowser = (
+    browser: string,
+    browserData: BrowserVersionData[],
+  ) => {
+    const [latestVersion, ...olderVersions] = browserData;
+    return html`
+      <div class="caniuse-browser">
+        ${renderLatestVersion(browser, latestVersion)}
+        <ul>
+          ${olderVersions.map(renderOlderVersion)}
+        </ul>
+      </div>
+    `;
+  };
+
+  const browsers = html`${Object.entries(data).map(([browser, browserData]) =>
+    renderBrowser(browser, browserData),
+  )}`;
+
+  const featureURL = new URL(options.feature, "https://caniuse.com/").href;
+  const moreInfo = html`<a href="${featureURL}">More info</a>`;
+
+  return html`${browsers} ${moreInfo}`.toString();
+}

--- a/routes/caniuse/lib/scraper.ts
+++ b/routes/caniuse/lib/scraper.ts
@@ -1,0 +1,122 @@
+// Reads features-json/*.json files from caniuse repository
+// and writes each file in a "respec friendly way"
+//  - Keep only the `stats` from features-json data
+//  - Sort browser versions (latest first)
+//  - Remove footnotes and other unnecessary data
+
+import * as path from "path";
+import { existsSync } from "fs";
+import { readFile, writeFile, readdir, mkdir } from "fs/promises";
+
+import sh from "../../../utils/sh.js";
+import { env } from "../../../utils/misc.js";
+
+interface Input {
+  stats: {
+    [browserName: string]: { [version: string]: string };
+  };
+}
+
+interface Output {
+  [browserName: string]: [string, ReturnType<typeof formatStatus>][];
+}
+
+const DATA_DIR = env("DATA_DIR");
+const INPUT_REPO_SRC = "https://github.com/Fyrd/caniuse.git";
+const INPUT_REPO_NAME = "caniuse-raw";
+const INPUT_DIR = path.join(DATA_DIR, INPUT_REPO_NAME, "features-json");
+const OUTPUT_DIR = path.join(DATA_DIR, "caniuse");
+
+const defaultOptions = { forceUpdate: false };
+type Options = typeof defaultOptions;
+
+export default async function main(options: Partial<Options> = {}) {
+  const opts = { ...defaultOptions, ...options };
+  const hasUpdated = await updateInputSource();
+  if (!hasUpdated && !opts.forceUpdate) {
+    console.log("Nothing to update");
+    return false;
+  }
+
+  console.log("INPUT_DIR:", INPUT_DIR);
+  console.log("OUTPUT_DIR:", OUTPUT_DIR);
+  if (!existsSync(OUTPUT_DIR)) {
+    await mkdir(OUTPUT_DIR, { recursive: true });
+  }
+
+  const fileNames = await readdir(INPUT_DIR);
+  console.log(`Processing ${fileNames.length} files...`);
+  const promisesToProcess = fileNames.map(processFile);
+  await Promise.all(promisesToProcess);
+  console.log(`Processed ${fileNames.length} files.`);
+  return true;
+}
+
+async function updateInputSource() {
+  const dataDir = path.join(DATA_DIR, INPUT_REPO_NAME);
+  const shouldClone = !existsSync(dataDir);
+
+  const command = shouldClone
+    ? `git clone ${INPUT_REPO_SRC} ${INPUT_REPO_NAME} --filter=blob:none`
+    : `git pull --depth=1`;
+  const cwd = shouldClone ? path.resolve(DATA_DIR) : dataDir;
+
+  const stdout = await sh(command, { cwd, output: "stream" });
+  const hasUpdated = !stdout.toString().includes("Already up to date");
+  return hasUpdated;
+}
+
+async function processFile(fileName: string) {
+  const inputFile = path.join(INPUT_DIR, fileName);
+  const outputFile = path.join(OUTPUT_DIR, fileName);
+
+  const json = await readJSON(inputFile);
+
+  const output: Output = {};
+  for (const [browserName, browserData] of Object.entries(json.stats)) {
+    const stats = Object.entries(browserData)
+      .sort(semverCompare)
+      .map(([version, status]) => [version, formatStatus(status)])
+      .reverse() as [string, string[]][];
+    output[browserName] = stats;
+  }
+
+  await writeJSON(outputFile, output);
+}
+
+type BrowserDataEntry = [string, string];
+/**
+ * semverCompare
+ * https://github.com/substack/semver-compare
+ */
+function semverCompare(a: BrowserDataEntry, b: BrowserDataEntry) {
+  const pa = a[0].split(".");
+  const pb = b[0].split(".");
+  for (let i = 0; i < 3; i++) {
+    const na = Number(pa[i]);
+    const nb = Number(pb[i]);
+    if (na > nb) return 1;
+    if (nb > na) return -1;
+    if (!isNaN(na) && isNaN(nb)) return 1;
+    if (isNaN(na) && !isNaN(nb)) return -1;
+  }
+  return 0;
+}
+
+/**  @example "n d #6" => ["n", "d"] */
+function formatStatus(status: string) {
+  return status
+    .split("#", 1)[0] // don't care about footnotes.
+    .split(" ")
+    .filter(item => item);
+}
+
+async function readJSON(file: string) {
+  const str = await readFile(file, "utf8");
+  return JSON.parse(str) as Input;
+}
+
+async function writeJSON(file: string, json: Output) {
+  const str = JSON.stringify(json);
+  await writeFile(file, str);
+}

--- a/routes/caniuse/update.js
+++ b/routes/caniuse/update.js
@@ -1,8 +1,8 @@
 // @ts-check
 import { queue } from "../../utils/background-task-queue.js";
 
-import { cache } from "respec-caniuse-route";
-import { main as scraper } from "respec-caniuse-route/scraper.js";
+import { cache } from "./lib/index.js";
+import scraper from "./lib/scraper.js";
 
 export default function route(req, res) {
   if (req.body.ref !== "refs/heads/master") {

--- a/scripts/update-data-sources.js
+++ b/scripts/update-data-sources.js
@@ -1,5 +1,6 @@
+import "../build/utils/dotenv.js";
+import caniuse from "../build/routes/caniuse/lib/scraper.js";
 import { main as xref } from "respec-xref-route/scraper.js";
-import { main as caniuse } from "respec-caniuse-route/scraper.js";
 
 async function update() {
   console.group("caniuse");

--- a/utils/sh.ts
+++ b/utils/sh.ts
@@ -1,0 +1,67 @@
+import { exec, ExecOptions } from "child_process";
+import split from "split2";
+
+type Logger = (line?: string) => void;
+interface Options extends ExecOptions {
+  output: "buffer" | "stream" | "silent";
+  log: { out: Logger; err: Logger };
+}
+
+const defaultLogger: Required<Options["log"]> = {
+  out: line => console.log(line),
+  err: line => console.log(line),
+};
+
+/**
+ * Asynchronously run a shell command get its result.
+ */
+export default async function sh(
+  command: string,
+  options: Options["output"] | Partial<Options> = {},
+) {
+  const { output = "silent", log = defaultLogger, ...execOptions } =
+    typeof options === "string" ? { output: options } : options;
+  const shouldStream =
+    output === "stream" || (typeof options !== "string" && !!options.log);
+
+  if (output !== "silent") {
+    const BOLD = "\x1b[1m";
+    const RESET = "\x1b[22m";
+    console.group(`${BOLD}$ ${command}${RESET}`);
+  }
+
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      let stdout = [];
+      let stderr = [];
+      const child = exec(command, {
+        ...execOptions,
+        env: { ...process.env, ...execOptions.env },
+        encoding: "utf-8",
+      });
+      child.stdout.pipe(split()).on("data", line => {
+        if (shouldStream) log.out(line);
+        stdout.push(line);
+      });
+      child.stderr.pipe(split()).on("data", line => {
+        if (shouldStream) log.err(line);
+        stderr.push(line);
+      });
+      child.on("exit", code => {
+        if (output === "buffer") {
+          if (stdout.length) log.out(stdout.join("\n"));
+          if (stderr.length) log.err(stderr.join("\n"));
+        }
+        if (code === 0) {
+          resolve(stdout.join("\n"));
+        } else {
+          reject({ command, stdout, stderr, code });
+        }
+      });
+    });
+  } finally {
+    if (output !== "silent") {
+      console.groupEnd();
+    }
+  }
+}


### PR DESCRIPTION
1. Brings https://github.com/sidvishnoi/respec-caniuse-route into this repo. I've chosen `routes/caniuse/lib` as the destination.
```diff
- import { createResponseBody } from "respec-caniuse-route";
+ import { createResponseBody } from "./lib/index.js";
```
2. Added a `sh` utility, which respec-caniuse-route/scraper and others can use consistently. I've used this it in [spec-prod](https://github.com/w3c/spec-prod/blob/215ce79becbf395ec938aa35a3d44de119fcf58e/src/utils.js#L82), so it's "well tested".
```diff
- const args = shouldClone
-   ? ['clone', 'https://github.com/Fyrd/caniuse.git', 'caniuse-raw']
-   : ['pull', 'origin', 'master'];
- const cwd = shouldClone ? path.resolve(DATA_DIR) : dataDir;

- return new Promise<boolean>((resolve, reject) => {
-   const git = spawn('git', args, { cwd });
-   let hasUpdated = true;
-   git.stdout.on('data', (data: ArrayBuffer) => {
-     hasUpdated = !data.toString().includes('Already up to date');
-   });
-   git.on('error', reject);
-   git.on('exit', (code: number) => {
-     if (code !== 0) {
-       reject(new Error(`The process exited with code ${code}`));
-     } else {
-       resolve(hasUpdated);
-     }
-   });
- });
+ const stdout = await sh(command, { cwd, output: "stream" });
+ const hasUpdated = !stdout.toString().includes("Already up to date");
+ return hasUpdated;
```
3. `routes/caniuse/lib/index.ts` makes use of `ucontent` instead of manipulating template strings. i.e.
```diff
-  return `<button class="${className}" title="${title}">${text}</button>`;
+  return html`<button class="${className}" title="${title}">${text}</button>`;
```
4. `routes/caniuse/lib/scraper.ts` does shallow git clone/pull to save space on server (from 125MB to 25MB). i.e.
```diff
- ['clone', 'https://github.com/Fyrd/caniuse.git', 'caniuse-raw']
+ `git clone ${INPUT_REPO_SRC} ${INPUT_REPO_NAME} --filter=blob:none`
```
5. `routes/caniuse/lib/index.ts` uses `utils/mem-cache` instead of its own cache.
6. No changes for end user.