### PR TITLE
fix(docs/update): write generated doc to correct location

### DIFF
--- a/routes/docs/update.js
+++ b/routes/docs/update.js
@@ -4,7 +4,8 @@ import { writeFile } from "fs/promises";
 
 import fetch from "node-fetch";
 
-import { HTTPError, legacyDirname } from "../../utils/misc.js";
+import { HTTPError } from "../../utils/misc.js";
+import { PROJECT_ROOT } from "../../utils/constants.js";
 /**
  * @param {import('express').Request} req
  * @param {import('express').Response} res
@@ -42,7 +43,6 @@ export async function regenerateDocs() {
   }
 
   const html = await res.text();
-  const __dirname = legacyDirname(import.meta);
-  const staticHtmlFile = path.join(__dirname, "../../static/docs/index.html");
+  const staticHtmlFile = path.join(PROJECT_ROOT, "static/docs/index.html");
   await writeFile(staticHtmlFile, html);
 }


### PR DESCRIPTION
Another regression from https://github.com/marcoscaceres/respec.org/pull/144

There are no more uses of `__dirname`, so this should be last.