### PR TITLE
fix(xref/scraper, caniuse/scraper): don't shallow clone

### DIFF
--- a/routes/caniuse/lib/scraper.ts
+++ b/routes/caniuse/lib/scraper.ts
@@ -57,8 +57,8 @@ async function updateInputSource() {
   const shouldClone = !existsSync(dataDir);
 
   const command = shouldClone
-    ? `git clone ${INPUT_REPO_SRC} ${INPUT_REPO_NAME} --filter=blob:none`
-    : `git pull --depth=1`;
+    ? `git clone ${INPUT_REPO_SRC} ${INPUT_REPO_NAME}`
+    : `git pull`;
   const cwd = shouldClone ? path.resolve(DATA_DIR) : dataDir;
 
   const stdout = await sh(command, { cwd, output: "stream" });

--- a/routes/xref/lib/scraper.ts
+++ b/routes/xref/lib/scraper.ts
@@ -78,8 +78,8 @@ async function updateInputSource() {
   const shouldClone = !existsSync(INPUT_DIR_BASE);
 
   const command = shouldClone
-    ? `git clone ${INPUT_REPO_SRC} ${INPUT_REPO_NAME} --filter=blob:none`
-    : `git pull --depth=1`;
+    ? `git clone ${INPUT_REPO_SRC} ${INPUT_REPO_NAME}`
+    : `git pull`;
   const cwd = shouldClone ? DATA_DIR : INPUT_DIR_BASE;
 
   const stdout = await sh(command, { output: "stream", cwd });


### PR DESCRIPTION
> Premature optimization is the root of all evil.

Regression from https://github.com/marcoscaceres/respec.org/pull/146, https://github.com/marcoscaceres/respec.org/pull/148 causing merge errors on pull.