### PR TITLE
fix(utils/background-task-queue): serialize/deserialize errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4497,6 +4497,21 @@
         }
       }
     },
+    "serialize-error": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.0.1.tgz",
+      "integrity": "sha512-r5o60rWFS+8/b49DNAbB+GXZA0SpDpuWE758JxDKgRTga05r3U5lwyksE91dYKDhXSmnu36RALj615E6Aj5pSg==",
+      "requires": {
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+        }
+      }
+    },
     "serve-static": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "nanoid": "^3.1.20",
     "node-fetch": "^2.6.1",
     "respec-github-apis": "^2.0.0",
+    "serialize-error": "^8.0.1",
     "split2": "^3.2.2",
     "ucontent": "^2.0.0"
   },


### PR DESCRIPTION
`Error` isn't serialized across `postMessage`.