### PR TITLE
chore: simplify update-data-sources script

### DIFF
--- a/scripts/regenerate-docs.js
+++ b/scripts/regenerate-docs.js
@@ -1,4 +1,4 @@
-import { regenerateDocs } from "../routes/docs/update.js";
+import { regenerateDocs } from "../build/routes/docs/update.js";
 
 (async () => {
   const start = Date.now();

--- a/scripts/update-data-sources.js
+++ b/scripts/update-data-sources.js
@@ -1,13 +1,23 @@
 import "../build/utils/dotenv.js";
 import caniuse from "../build/routes/caniuse/lib/scraper.js";
 import xref from "../build/routes/xref/lib/scraper.js";
+import w3cGroupsList from "./update-w3c-groups-list.js";
 
 async function update() {
   console.group("caniuse");
   await caniuse();
   console.groupEnd();
+
   console.group("xref");
   await xref();
+  console.groupEnd();
+
+  console.group("W3C Groups List");
+  if (process.env.W3C_API_KEY) {
+    await w3cGroupsList();
+  } else {
+    console.log("Skipped.");
+  }
   console.groupEnd();
 }
 

--- a/scripts/update-data-sources.js
+++ b/scripts/update-data-sources.js
@@ -13,11 +13,7 @@ async function update() {
   console.groupEnd();
 
   console.group("W3C Groups List");
-  if (process.env.W3C_API_KEY) {
-    await w3cGroupsList();
-  } else {
-    console.log("Skipped.");
-  }
+  await w3cGroupsList();
   console.groupEnd();
 }
 

--- a/scripts/update-w3c-groups-list.js
+++ b/scripts/update-w3c-groups-list.js
@@ -24,6 +24,19 @@ const mapGroupType = new Map([
 ]);
 
 export default async function update() {
+  const data = Object.fromEntries(
+    [...mapGroupType.values()].map(type => [type, {}]),
+  );
+  if (process.env.W3C_API_KEY === "IGNORE") {
+    console.warn("No W3C_API_KEY is set.");
+    console.warn(
+      `Skipping update, but writing boilerplate data to ${OUTPUT_FILE}`,
+    );
+    await mkdir(path.dirname(OUTPUT_FILE), { recursive: true });
+    await writeFile(OUTPUT_FILE, JSON.stringify(data, null, 2), "utf-8");
+    return;
+  }
+
   console.log("Updating W3C groups list...");
   const apiUrl = new URL("https://api.w3.org/groups/");
   apiUrl.searchParams.set("apikey", env("W3C_API_KEY"));
@@ -32,9 +45,6 @@ export default async function update() {
   const json = await fetch(apiUrl).then(r => r.json());
 
   console.log("Processing results...");
-  const data = Object.fromEntries(
-    [...mapGroupType.values()].map(type => [type, {}]),
-  );
   for (const group of json._embedded.groups) {
     const type = mapGroupType.get(group.type);
     if (!type) continue;

--- a/scripts/update-w3c-groups-list.js
+++ b/scripts/update-w3c-groups-list.js
@@ -22,13 +22,15 @@ const mapGroupType = new Map([
   ["_miscellaneous_", "misc"],
 ]);
 
-async function update() {
+export default async function update() {
+  console.log("Updating W3C groups list...");
   const apiUrl = new URL("https://api.w3.org/groups/");
   apiUrl.searchParams.set("apikey", env("W3C_API_KEY"));
   apiUrl.searchParams.set("embed", "true");
   apiUrl.searchParams.set("items", "500");
   const json = await fetch(apiUrl).then(r => r.json());
 
+  console.log("Processing results...");
   const data = Object.fromEntries(
     [...mapGroupType.values()].map(type => [type, {}]),
   );
@@ -70,7 +72,3 @@ async function update() {
   await writeFile(OUTPUT_FILE, JSON.stringify(data, null, 2), "utf-8");
 }
 
-update().catch(error => {
-  console.log(error);
-  process.exit(1);
-});

--- a/scripts/update-w3c-groups-list.js
+++ b/scripts/update-w3c-groups-list.js
@@ -4,6 +4,7 @@
  */
 
 import path from "path";
+import { fileURLToPath } from "url";
 import { writeFile, mkdir } from "fs/promises";
 
 import fetch from "node-fetch";
@@ -72,3 +73,15 @@ export default async function update() {
   await writeFile(OUTPUT_FILE, JSON.stringify(data, null, 2), "utf-8");
 }
 
+const runAsScript = (() => {
+  const modulePath = fileURLToPath(import.meta.url);
+  const scriptPath = process.argv[1];
+  return modulePath === scriptPath;
+})();
+
+if (runAsScript) {
+  update().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes https://github.com/marcoscaceres/respec.org/issues/123
Closes https://github.com/marcoscaceres/respec.org/issues/124

Getting started now is:
1. Clone repo, npm install
2. Copy `.env.sample` to `.env`
   1. Set `DATA_DIR`  to `pwd` + `"data"` (or some path outside repo)
   2. Set `W3C_API_KEY` to `"IGNORE"` (or if you have key, use it. Without a correct key, `/w3c/*` pages will error when viewed).
   3. Let everything else stay same.
3. `npm run update-data-sources`
4. (Optional) `node scripts/regenerate-docs.js`