### PR TITLE
feat(utils/disk-cache): add filesystem-backed persistent cache

### DIFF
--- a/utils/disk-cache.ts
+++ b/utils/disk-cache.ts
@@ -1,0 +1,109 @@
+import path from "path";
+import { mkdir, readFile, unlink, writeFile } from "fs/promises";
+
+import { env } from "./misc.js";
+import { MemCache } from "./mem-cache.js";
+
+interface CacheEntry<V> {
+  time: number;
+  value: V;
+}
+
+interface Options {
+  /** Cache TTL in ms */
+  ttl: number;
+  /** Cache directory for persistent storage */
+  path: string;
+  /** Automatically evict stale entries every `autoEvict` ms */
+  autoEvictInterval?: number;
+}
+
+/**
+ * An in-memory cache persisted through filesystem.
+ */
+export class DiskCache<ValueType> {
+  #ttl: number;
+  #path: string;
+  #memCache: MemCache<ValueType>;
+
+  constructor(options: Options) {
+    this.#ttl = options.ttl;
+    this.#path = options.path;
+    this.#memCache = new MemCache(options.ttl);
+    if (options.autoEvictInterval) {
+      setInterval(this.invalidate.bind(this), options.autoEvictInterval);
+    }
+  }
+
+  /**
+   * Store a key-value pair in memory as well as on filesystem.
+   */
+  async set(key: string, value: ValueType) {
+    const time = Date.now();
+    this.#memCache.set(key, value, time);
+    await this.write(key, { time, value });
+  }
+
+  /**
+   * Try to get entry from memory, if that misses, try from filesystem.
+   *
+   * Hits from filesystem are loaded into memory for faster future access. Stale
+   * hits are evicted unless `allowStale` is true.
+   */
+  async get(key: string, allowStale?: boolean) {
+    if (!this.#memCache.has(key, allowStale)) {
+      const entry = await this.read(key);
+      if (!entry) {
+        return undefined;
+      }
+      if (this.isBusted(entry.time) && !allowStale) {
+        // If the filesystem content is state and stale is not requested, delete
+        // it from filesystem and do not load it in memory.
+        await this.delete(key);
+        return undefined;
+      }
+      this.#memCache.set(key, entry.value, entry.time);
+    }
+
+    return this.#memCache.get(key, allowStale);
+  }
+
+  /**
+   * Remove stale entries from memory as well as filesystem.
+   */
+  async invalidate() {
+    const invalidatedKeys = this.#memCache.invalidate();
+    await Promise.all(invalidatedKeys.map(key => this.delete(key)));
+  }
+
+  private isBusted(time: number) {
+    return Date.now() - time > this.#ttl;
+  }
+
+  private async read(key: string) {
+    const fileName = this.keyToFilePath(key);
+    try {
+      const text = await readFile(fileName, "utf-8");
+      return JSON.parse(text) as CacheEntry<ValueType>;
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        console.error(error);
+      }
+    }
+  }
+
+  private async write(key: string, entry: CacheEntry<ValueType>) {
+    const fileName = this.keyToFilePath(key);
+    await mkdir(path.dirname(fileName), { recursive: true });
+    await writeFile(fileName, JSON.stringify(entry, null, 2), "utf-8");
+  }
+
+  private async delete(key: string) {
+    const fileName = this.keyToFilePath(key);
+    await unlink(fileName);
+  }
+
+  private keyToFilePath(key: string) {
+    return path.join(env("DATA_DIR"), this.#path, `${key}.json`);
+  }
+}


### PR DESCRIPTION
Added in `DiskCache` which persists caching across app restarts, which is useful with expensive operations. It'll allow us to restart server often without losing the cached data. It's a database, but without the hassle of a database.

This filesystem-backed cache is used internally in [respec-github-apis](https://github.com/sidvishnoi/respec-github-apis) as [`TTLCache`](https://github.com/sidvishnoi/respec-github-apis/blob/main/utils/cache.ts). I'm bringing it here in this PR as a step to move respec-github-apis into this repo, similar to https://github.com/marcoscaceres/respec.org/pull/146 and https://github.com/marcoscaceres/respec.org/pull/148.

As a demonstration, I converted `/github/org/repo/contributors` endpoint to use the disk cache:

|                    | Before                              | After                               |
| ------------------ | ----------------------------------- | ----------------------------------- |
| **First app load** |                                     |                                     |
|                    | `2573.480 ms # cache miss`          | `2452.966 ms # cache miss`          |
|                    | ` 1.152 ms # cached in memory`      | ` 1.179 ms # cached in memory`      |
| **Restart app**    |                                     |                                     |
|                    | `2538.911 ms # cache miss`          | ` 6.387 ms # cache hit from disk`   |
|                    | ` 1.277 ms # cache hit from memory` | ` 1.056 ms # cache hit from memory` |
