### PR TITLE
refactor(*): remove unnecessary OPTIONS requests

### DIFF
--- a/routes/caniuse/index.ts
+++ b/routes/caniuse/index.ts
@@ -10,7 +10,6 @@ import updateRoute from "./update.js";
 
 const caniuse = Router({ mergeParams: true });
 
-caniuse.options("/", cors({ methods: ["GET"] }));
 caniuse.get("/", cors(), route);
 caniuse.post("/update", authGithubWebhook(env("CANIUSE_SECRET")), updateRoute);
 

--- a/routes/github/index.ts
+++ b/routes/github/index.ts
@@ -7,17 +7,9 @@ import commitsRoute from "./commits.js";
 import filesRoute from "./files.js";
 
 const gh = Router({ mergeParams: true });
-
-gh.options("/contributors", cors({ methods: ["GET"] }));
 gh.get("/contributors", cors(), contributorsRoute);
-
-gh.options("/issues", cors({ methods: ["GET"] }));
 gh.get("/issues", cors(), issuesRoute);
-
-gh.options("/commits", cors({ methods: ["GET"] }));
 gh.get("/commits", cors(), commitsRoute);
-
-gh.options("/files", cors({ methods: ["GET"] }));
 gh.get("/files", cors(), filesRoute);
 
 export default gh;

--- a/routes/w3c/index.ts
+++ b/routes/w3c/index.ts
@@ -4,8 +4,6 @@ import cors from "cors";
 import groupsRoute from "./group.js";
 
 const w3c = Router();
-
-w3c.options("/groups/:shortname?/:type?", cors({ methods: ["GET"] }));
 w3c.get("/groups/:shortname?/:type?", cors(), groupsRoute);
 
 export default w3c;

--- a/routes/xref/index.ts
+++ b/routes/xref/index.ts
@@ -5,7 +5,7 @@ import cors from "cors";
 import { Request, Response } from "express";
 
 import authGithubWebhook from "../../utils/auth-github-webhook.js";
-import { env } from "../../utils/misc.js";
+import { env, ms } from "../../utils/misc.js";
 
 import { store } from "./lib/store-init.js";
 import metaRoute from "./meta.js";
@@ -16,7 +16,7 @@ const DATA_DIR = env("DATA_DIR");
 
 const xref = express.Router({ mergeParams: true });
 
-xref.options("/", cors({ methods: ["POST", "GET"] }));
+xref.options("/", cors({ methods: ["POST"], maxAge: ms("1day") }));
 xref.post("/", express.json(), cors(), route);
 xref.get("/meta/:field?", cors(), metaRoute);
 xref.post("/update", authGithubWebhook(env("W3C_WEBREF_SECRET")), updateRoute);


### PR DESCRIPTION
..as these are simple-request endpoints that don't require pre-flight requests.

Also set maxAge for /xref pre-flight request (Closes https://github.com/marcoscaceres/respec.org/issues/150)