### PR TITLE
feat(specref-ui): add a UI for Specref search

### DIFF
--- a/static/specref/index.html
+++ b/static/specref/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Search Specref</title>
+    <link rel="stylesheet" href="style.css?v=75d77bcc" />
+    <script src="script.js?v=7da9a9ee" defer></script>
+  </head>
+  <body>
+    <header>
+      <p>
+        An Open-Source, Community-Maintained Database of Web Standards & Related
+        References.
+      </p>
+    </header>
+    <main>
+      <form action="https://www.specref.org/">
+        <div class="field">
+          <input
+            name="q"
+            type="search"
+            aria-label="Search"
+            autocomplete="off"
+            placeholder="Keywords, titles, authors, urls…"
+            required
+            autofocus
+          />
+          <button type="submit">Search</button>
+        </div>
+        <label class="options">
+          <input type="checkbox" name="includeAllVersions" /> Include all
+          versions.
+        </label>
+      </form>
+      <output></output>
+    </main>
+  </body>
+</html>

--- a/static/specref/script.js
+++ b/static/specref/script.js
@@ -1,0 +1,176 @@
+const form = document.querySelector("form");
+const output = document.querySelector("output");
+/** @type {HTMLInputElement} */
+const searchBox = form.querySelector("input[name=q]");
+
+const API_URL = new URL("https://api.specref.org/");
+
+const REF_STATUSES = new Map([
+  ["CR", "W3C Candidate Recommendation"],
+  ["ED", "W3C Editor's Draft"],
+  ["FPWD", "W3C First Public Working Draft"],
+  ["LCWD", "W3C Last Call Working Draft"],
+  ["NOTE", "W3C Note"],
+  ["PER", "W3C Proposed Edited Recommendation"],
+  ["PR", "W3C Proposed Recommendation"],
+  ["REC", "W3C Recommendation"],
+  ["WD", "W3C Working Draft"],
+  ["WG-NOTE", "W3C Working Group Note"],
+]);
+
+const defaultsReference = Object.freeze({
+  authors: [],
+  date: "",
+  href: "",
+  publisher: "",
+  status: "",
+  title: "",
+  etAl: false,
+});
+
+form.addEventListener("submit", async ev => {
+  ev.preventDefault();
+  const query = searchBox.value;
+  if (!query) {
+    searchBox.focus();
+    return;
+  }
+
+  render({ state: "Searching Specref…" });
+  const refSearch = new URL("search-refs", API_URL);
+  refSearch.searchParams.set("q", query);
+  const reverseLookup = new URL("reverse-lookup", API_URL);
+  reverseLookup.searchParams.set("urls", query);
+
+  try {
+    const startTime = performance.now();
+    const jsonData = await Promise.all([
+      fetch(refSearch.href).then(response => response.json()),
+      fetch(reverseLookup.href).then(response => response.json()),
+    ]);
+    const includeAllVersions = form.includeAllVersions.checked;
+    const results = processResults({ includeAllVersions }, ...jsonData);
+    render({
+      query,
+      results,
+      state: "",
+      timeTaken: Math.round(performance.now() - startTime) / 1000,
+    });
+  } catch (err) {
+    console.error(err);
+    render({ state: "Error! Couldn't do search." });
+  } finally {
+    searchBox.focus();
+  }
+});
+
+function processResults({ includeAllVersions = false }, ...fetchedData) {
+  /** @type {{ [key: string]: any }} */
+  const combinedResults = Object.assign({}, ...fetchedData);
+  const results = new Map(Object.entries(combinedResults));
+  // remove aliases
+  Array.from(results)
+    .filter(([, entry]) => entry.aliasOf)
+    .map(([key]) => key)
+    .reduce((results, key) => results.delete(key) && results, results);
+  // Remove versions, if asked to
+  if (!includeAllVersions) {
+    Array.from(results.values())
+      .filter(entry => typeof entry === "object" && "versions" in entry)
+      .flat()
+      .forEach(version => {
+        results.delete(version);
+      });
+  }
+  // Remove legacy string entries
+  Array.from(results)
+    .filter(([, value]) => typeof value !== "object")
+    .forEach(([key]) => results.delete(key));
+  return results;
+}
+
+function render({ state = "", results, timeTaken, query } = {}) {
+  const hidden = !state ? "hidden" : "";
+  const stateHTML = `<p class="state" ${hidden}>${state}</p>`;
+
+  if (!results) {
+    output.innerHTML = stateHTML;
+    return;
+  }
+  const renderedResults = renderResults(results, query, timeTaken);
+  const html = `<section aria-live="polite">${renderedResults}</section>`;
+  output.innerHTML = stateHTML + html;
+}
+
+/**
+ * @param {Map<string, string>} resultMap
+ * @param {string} query
+ * @param {number} timeTaken
+ */
+function renderResults(resultMap, query, timeTaken) {
+  if (!resultMap.size) {
+    return `
+      <p class="state">
+        Your search - <strong>${query}</strong> -
+        did not match any references.
+      </p>
+    `;
+  }
+  const definitionPairs = Array.from(resultMap)
+    .slice(0, 99)
+    .map(toDefinitionPair)
+    .reduce((collector, pair) => collector.concat(pair), []);
+  return `
+    <p class="result-stats">
+      ${resultMap.size} results (${timeTaken} seconds).
+      ${resultMap.size > 99 ? "Showing first 100 results." : ""}
+    </p>
+    <dl class="specref-results">${definitionPairs.join("\n")}</dl>
+  `;
+}
+
+function toDefinitionPair([key, entry]) {
+  return `
+    <dt>[${key}]</dt>
+    <dd>${wireReference(entry)}</dd>
+  `;
+}
+
+function wireReference(rawRef) {
+  if (typeof rawRef !== "object") {
+    throw new TypeError("Only modern object references are allowed");
+  }
+  const ref = Object.assign({}, defaultsReference, rawRef);
+  const authors = ref.authors.join("; ") + (ref.etAl ? " et al" : "");
+  const status = REF_STATUSES.get(ref.status) || ref.status;
+  return `
+    <cite>
+      <a
+        href="${ref.href}"
+        target="_blank"
+        rel="noopener noreferrer">
+        ${ref.title.trim()}</a>.
+    </cite>
+    <span class="authors">
+      ${endWithDot(authors)}
+    </span>
+    <span class="publisher">
+      ${endWithDot(ref.publisher)}
+    </span>
+    <span class="pubDate">
+      ${endWithDot(ref.date)}
+    </span>
+    <span class="pubStatus">
+      ${endWithDot(status)}
+    </span>
+  `;
+}
+
+/** @param {string} str */
+function endWithDot(str) {
+  const trimmed = str.trim();
+  if (!trimmed || trimmed.endsWith(".")) {
+    return trimmed;
+  }
+  return trimmed + ".";
+}

--- a/static/specref/style.css
+++ b/static/specref/style.css
@@ -1,0 +1,104 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  line-height: 1.4;
+}
+
+header {
+  background-color: #eee;
+  text-align: center;
+  padding: 0.5em;
+  margin: 0 2%;
+  margin-bottom: 1em;
+  border-radius: 0 0 0.5em 0.5em;
+}
+
+p {
+  font-size: small;
+  text-align: center;
+}
+
+main {
+  display: grid;
+  gap: 1em;
+  margin: 0 auto 1em;
+  justify-content: stretch;
+  width: 100%;
+  max-width: 800px;
+  width: clamp(200px, 100vw, 800px);
+}
+
+form,
+output {
+  padding: 0 1em;
+}
+
+form .field {
+  margin: 0.5em 0;
+  display: flex;
+}
+form .field > * {
+  padding: 0.5em;
+}
+
+form label {
+  font-size: smaller;
+  line-height: 1.5;
+}
+
+form label.options {
+  float: right;
+}
+
+form input[type="checkbox"] {
+  vertical-align: middle;
+}
+
+form input[type="search"] {
+  width: 100%;
+  border: 1px solid #005a9c;
+  border-radius: 2px 0 0 2px;
+}
+
+form button {
+  border: none;
+  background: #005a9c;
+  color: #fff;
+  border-radius: 0 2px 2px 0;
+  padding: 0.5em;
+}
+
+form button:hover,
+form button:focus {
+  background: #08314f;
+  cursor: pointer;
+}
+
+.result-stats {
+  margin-bottom: 1em;
+  color: #555;
+}
+
+.specref-results dt {
+  font-weight: bold;
+}
+
+.specref-results dd + dt {
+  margin-top: 0.51cm;
+}
+
+.specref-results a {
+  color: #034575;
+  text-transform: capitalize;
+}
+
+.specref-results .authors {
+  display: block;
+  color: #006621;
+}


### PR DESCRIPTION
Moved from w3c/respec along with some improvements.
Demo: https://raw.githack.com/marcoscaceres/respec.org/specref-ui/static/specref/index.html

<details>
<summary>Potential size changes in ReSpec</summary>

| File             | Before |  After |  Diff |
| ---------------- | -----: | -----: | ----: |
| respec-w3c.js    | 308252 | 304014 | -4238 |
| respec-w3c.js.br |  84815 |  83563 | -1252 |
| respec-w3c.js.gz |  98219 |  96754 | -1465 |

</details>