### PR TITLE
fix(app): load views from build directory

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -6,6 +6,7 @@ import helmet from "helmet";
 
 import * as logging from "./utils/logging.js";
 import { register as registerViewEngine } from "./utils/view-engine.js";
+import { legacyDirname } from "./utils/misc.js";
 import { PROJECT_ROOT } from "./utils/constants.js";
 import "./utils/dotenv.js";
 
@@ -26,7 +27,7 @@ app.use(logging.stderr());
 
 app.use(express.static(path.join(PROJECT_ROOT, "/static")));
 
-app.set("views", path.join(PROJECT_ROOT, "views"));
+app.set("views", path.join(legacyDirname(import.meta), "views"));
 registerViewEngine(app);
 
 // Security


### PR DESCRIPTION
Fixes following error when accessing `/w3c/groups` (regression from https://github.com/marcoscaceres/respec.org/pull/176):
```
Error: Failed to lookup view "w3c/groups.js" in views directory "/path/to/respec.org/views"
    at Function.render (/path/to/respec.org/node_modules/express/lib/application.js:580:17)
    at ServerResponse.render (/path/to/respec.org/node_modules/express/lib/response.js:1012:7)
    at route (file:///path/to/respec.org/routes/w3c/group.ts:46:18)
    at Layer.handle [as handle_request] (/path/to/respec.org/node_modules/express/lib/router/layer.js:95:5)
    at next (/path/to/respec.org/node_modules/express/lib/router/route.js:137:13)
    at cors (/path/to/respec.org/node_modules/cors/lib/index.js:188:7)
    at /path/to/respec.org/node_modules/cors/lib/index.js:224:17
    at originCallback (/path/to/respec.org/node_modules/cors/lib/index.js:214:15)
    at /path/to/respec.org/node_modules/cors/lib/index.js:219:13
    at optionsCallback (/path/to/respec.org/node_modules/cors/lib/index.js:199:9)
```