### PR TITLE
fix(xref/scraper): ensure data by term is unique

### DIFF
--- a/routes/xref/lib/scraper.ts
+++ b/routes/xref/lib/scraper.ts
@@ -79,6 +79,10 @@ export default async function main(options: Partial<Options> = {}) {
     }
   }
 
+  for (const term of Object.keys(dataByTerm)) {
+    dataByTerm[term] = uniq(dataByTerm[term]);
+  }
+
   console.log("Writing processed data files...");
   await mkdir(OUT_DIR_BASE, { recursive: true });
   await Promise.all([


### PR DESCRIPTION
Also reduce `xref.json` size from `9771157` to `9512071` (minus 259086 bytes, or ~250KiB)