### PR TITLE
Update docs

### DIFF
--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -228,7 +228,6 @@
     <section data-max-toc="1" data-include="markdown"></section>
     <section>
       <h2>Configuration Options</h2>
-      <section data-include="a11y"></section>
       <section data-include="addSectionLinks"></section>
       <section data-include="authors"></section>
       <section data-include="caniuse"></section>
@@ -242,6 +241,7 @@
       <section data-include="license"></section>
       <section data-include-name="lint" data-max-toc="2">
         <section data-include="lint" data-include-replace="true"></section>
+        <section data-include="a11y"></section>
         <section data-include="no-http-props"></section>
         <section data-include="local-refs-exist"></section>
         <section data-include="no-headingless-sections"></section>

--- a/static/docs/src.html
+++ b/static/docs/src.html
@@ -255,6 +255,7 @@
       <section data-include="maxTocLevel"></section>
       <section data-include="mdn"></section>
       <section data-include="modificationDate"></section>
+      <section data-include="monetization"></section>
       <section data-include="noTOC"></section>
       <section data-include="otherLinks"></section>
       <section data-include="pluralize"></section>


### PR DESCRIPTION
TODO:
- [x] When new ReSpec is released, update https://github.com/w3c/respec/wiki/a11y to reflect `respecConfig.lint.a11y` as primary config method.